### PR TITLE
Update endpoint configs on prod env

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,6 +2,6 @@ import Config
 
 config :web, Web.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: [host: nil],
+  url: [scheme: "https", host: System.get_env("HOST"), port: 443],
   force_ssl: [rewrite_on: [:x_forwarded_proto], host: nil],
   cache_static_manifest: "priv/static/cache_manifest.json"


### PR DESCRIPTION
resolves #22 

* `HOST` env var to assign the domain `branchpage.com` no production app.