### PR TITLE
Remove https configs

### DIFF
--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,8 +2,6 @@ import Config
 
 config :web, Web.Endpoint,
   http: [port: {:system, "PORT"}],
-  url: nil,
-  force_ssl: [rewrite_on: [:x_forwarded_proto], host: nil],
   cache_static_manifest: "priv/static/cache_manifest.json"
 
 config :logger, level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -3,6 +3,6 @@ import Config
 config :web, Web.Endpoint,
   http: [port: {:system, "PORT"}],
   cache_static_manifest: "priv/static/cache_manifest.json",
-  check_origin: ["//branchpage.com"]
+  check_origin: ["//branchpage.com", "//*.branchpage.com"]
 
 config :logger, level: :info

--- a/config/prod.exs
+++ b/config/prod.exs
@@ -2,6 +2,7 @@ import Config
 
 config :web, Web.Endpoint,
   http: [port: {:system, "PORT"}],
-  cache_static_manifest: "priv/static/cache_manifest.json"
+  cache_static_manifest: "priv/static/cache_manifest.json",
+  check_origin: ["//branchpage.com"]
 
 config :logger, level: :info


### PR DESCRIPTION
it won't run using `.herokuapp` domain anymore.  
The environments are now
* http://www.branchpage.com
* http://hml.branchpage.com
* http://stg.branchpage.com