### PR TITLE
Remove env from production stage

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -58,7 +58,6 @@ FROM alpine:3.13.3
 WORKDIR /branchpage
 
 ARG MIX_ENV=prod
-ENV MIX_ENV=$MIX_ENV
 
 # install dependencies
 RUN apk add ncurses-libs curl


### PR DESCRIPTION
production environment doesn't need a `MIX_ENV` variable since there is no `mix` command running.