### PR TITLE
Fix - show username on post when there is no fullname associated to user

### DIFF
--- a/apps/web/lib/web/live/article_live.ex
+++ b/apps/web/lib/web/live/article_live.ex
@@ -19,8 +19,7 @@ defmodule Web.ArticleLive do
     article = Manage.load_article!(username, id)
 
     meta = %{@meta | title: "#{article.title} – Branchpage"}
-    name = article.blog.fullname || "Go to your blog"
-    username = article.blog.username
+    name = article.blog.fullname || username
 
     socket =
       socket


### PR DESCRIPTION
show username on post when there is no fullname associated to user

![image](https://user-images.githubusercontent.com/47092331/126050768-bda604fc-a0d7-4a5d-91d6-43ede452139d.png)
